### PR TITLE
include dotnet runtime so it doesn't need to be installed separately

### DIFF
--- a/.github/workflows/publish-project.yml
+++ b/.github/workflows/publish-project.yml
@@ -29,13 +29,13 @@ jobs:
         node-version: 20.x
 
     - name: Build
-      run: dotnet build Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj -c Release -r win-x64
+      run: dotnet build Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj -c Release -r win-x64 --self-contained
 
     - name: Test .NET
       run: dotnet test Battelle.EPA.WideAreaDecon.API.Tests/Battelle.EPA.WideAreaDecon.API.Tests.csproj --no-build -c Release --verbosity normal
     
     - name: Publish
-      run: dotnet publish Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj --no-build -c Release -o ./publish -r win-x64
+      run: dotnet publish Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj --no-build -c Release -o ./publish -r win-x64 --self-contained
 
     - name: Copy Build Files
       run: cp -R ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/gdal, ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/Battelle.RiskAssessment.Common.Statistics.Native.*  ./publish

--- a/.github/workflows/publish-project.yml
+++ b/.github/workflows/publish-project.yml
@@ -38,7 +38,7 @@ jobs:
       run: dotnet publish Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj --no-build -c Release -o ./publish -r win-x64 --self-contained
 
     - name: Copy Build Files
-      run: cp -R ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/gdal, ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/Battelle.RiskAssessment.Common.Statistics.Native.*  ./publish
+      run: cp -R ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/win-x64/gdal, ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/win-x64/Battelle.RiskAssessment.Common.Statistics.Native.*  ./publish
 
     - name: Test Typescript
       working-directory: Battelle.EPA.WideAreaDecon.Client

--- a/.github/workflows/publish-project.yml
+++ b/.github/workflows/publish-project.yml
@@ -29,13 +29,13 @@ jobs:
         node-version: 20.x
 
     - name: Build
-      run: dotnet build Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj -c Release
+      run: dotnet build Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj -c Release -r win-x64
 
     - name: Test .NET
       run: dotnet test Battelle.EPA.WideAreaDecon.API.Tests/Battelle.EPA.WideAreaDecon.API.Tests.csproj --no-build -c Release --verbosity normal
     
     - name: Publish
-      run: dotnet publish Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj --no-build -c Release -o ./publish
+      run: dotnet publish Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj --no-build -c Release -o ./publish -r win-x64
 
     - name: Copy Build Files
       run: cp -R ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/gdal, ./Battelle.EPA.WideAreaDecon.API/bin/Release/net6.0/Battelle.RiskAssessment.Common.Statistics.Native.*  ./publish

--- a/Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj
+++ b/Battelle.EPA.WideAreaDecon.API/Battelle.EPA.WideAreaDecon.API.csproj
@@ -11,7 +11,7 @@
     <Description>Application to calculate the decontamination costs associated with a wide area contamination event</Description>
     <AssemblyName>Battelle.EPA.WideAreaDecon.API</AssemblyName>
     <RootNamespace>Battelle.EPA.WideAreaDecon.API</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ElectronNET.API" Version="7.30.2" />

--- a/Battelle.EPA.WideAreaDecon.API/Models/ClientConfiguration/ClientConfiguration.cs
+++ b/Battelle.EPA.WideAreaDecon.API/Models/ClientConfiguration/ClientConfiguration.cs
@@ -23,7 +23,7 @@ namespace Battelle.EPA.WideAreaDecon.API.Models.ClientConfiguration
         /// The title of the current application
         /// </summary>
         [JsonProperty("applicationTitle")]
-        public string Title => "Wide-Area Decontamination Tool";
+        public string Title => "Wide-Area Biodecon Resource Estimation Tool";
 
         /// <summary>
         /// The publisher of the application 
@@ -35,12 +35,12 @@ namespace Battelle.EPA.WideAreaDecon.API.Models.ClientConfiguration
         /// The acronym for the application
         /// </summary>
         [JsonProperty("applicationAcronym")]
-        public string Acronym => "WADT";
+        public string Acronym => "WABRET";
 
         /// <summary>
         /// The agency sponsoring the development of the application
         /// </summary>
         [JsonProperty("applicationSponsor")]
-        public string Sponsor => "Environment Protection Agency : Office of Research and Development";
+        public string Sponsor => "Environmental Protection Agency : Office of Research and Development";
     }
 }

--- a/Battelle.EPA.WideAreaDecon.Client/package-lock.json
+++ b/Battelle.EPA.WideAreaDecon.Client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wide-area-decon-tool",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wide-area-decon-tool",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/Battelle.EPA.WideAreaDecon.Client/package.json
+++ b/Battelle.EPA.WideAreaDecon.Client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wide-area-decon-tool",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/Battelle.EPA.WideAreaDecon.Client/public/index.html
+++ b/Battelle.EPA.WideAreaDecon.Client/public/index.html
@@ -7,11 +7,11 @@
     <link rel="shortcut icon" href="<%= BASE_URL %>epaLogo.ico">
     <link rel="icon" href="<%= BASE_URL %>epaLogo.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto:100:300,400,500,700,900|Material+Icons" rel="stylesheet">
-    <title>Wide-Area Decon Tool</title>
+    <title>Wide-Area Biodecon Resource Estimation Tool</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but wide area decon tool doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but the Wide-Area Biodecon Resource Estimation Tool doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/Battelle.EPA.WideAreaDecon.Client/src/components/adjustmentPages/DefineScenario.vue
+++ b/Battelle.EPA.WideAreaDecon.Client/src/components/adjustmentPages/DefineScenario.vue
@@ -12,7 +12,7 @@
 
             <v-dialog v-model="option.helpActive" max-width="600">
               <template v-slot:activator="{ on }">
-                <v-icon v-on="on">help</v-icon>
+                <v-icon v-on="on">mdi-help-circle</v-icon>
               </template>
               <v-card class="mx-auto">
                 <v-system-bar class="mb-3" color="primary" height="60">

--- a/Battelle.EPA.WideAreaDecon.Client/src/components/modals/HomeOptionHelp.vue
+++ b/Battelle.EPA.WideAreaDecon.Client/src/components/modals/HomeOptionHelp.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="dialog" :max-width="maxWidth">
     <template v-slot:activator="{ on }">
-      <v-icon v-on="on" @click="selectedHelpItem = item">help</v-icon>
+      <v-icon v-on="on" @click="selectedHelpItem = item">mdi-help-circle</v-icon>
     </template>
     <v-card class="mx-auto">
       <v-system-bar class="mb-3" color="primary" height="60">

--- a/Battelle.EPA.WideAreaDecon.Client/src/components/parameters/maps/CityMap.vue
+++ b/Battelle.EPA.WideAreaDecon.Client/src/components/parameters/maps/CityMap.vue
@@ -554,7 +554,7 @@ export default class CityMap extends Vue {
         return;
       }
 
-      if (file.type !== 'application/zip' && !file.name.endsWith('.kml')) {
+      if (file.type !== 'application/zip' && file.type !== 'application/x-zip-compressed' && !file.name.endsWith('.kml')) {
         alert('Only kml or Shapefile zips are supported');
         return;
       }

--- a/InstallerFiles/deconToolInstaller.electron.manifest.json
+++ b/InstallerFiles/deconToolInstaller.electron.manifest.json
@@ -1,6 +1,6 @@
 {
   "executable": "Battelle.EPA.WideAreaDecon.API",
-  "description": "Wide Area Decontamination Tool",
+  "description": "Wide-Area Biodecon Resource Estimation Tool",
   "name": "wide-area-decon",
   "author": "Battelle Memorial Institute",
   "splashscreen": {
@@ -10,9 +10,9 @@
   "cacheDirectory": "resources/cache",
   "build": {
     "appId": "com.electron.Battelle.WideAreaDeconTool.app",
-    "productName": "Wide Area Decon",
+    "productName": "Wide-Area Biodecon Resource Estimation Tool",
     "copyright": "Copyright 2023",
-    "buildVersion": "1.1.0",
+    "buildVersion": "1.1.1",
     "compression": "maximum",
     "directories": {
       "output": "",


### PR DESCRIPTION
- bundle app with dotnet runtime, so that it no longer needs to be installed separately
- update app display name
- fix a few bugs when running in electron